### PR TITLE
Allows for multiple <template></template> tags in .vue file without breaking highlighting

### DIFF
--- a/syntax/vue.vim
+++ b/syntax/vue.vim
@@ -8,14 +8,14 @@ endif
 
 syntax include @HTML syntax/html.vim
 unlet b:current_syntax
-syntax region template keepend start=/<template\( lang="[a-zA-Z]\+"\)\?>/ end="</template>" contains=@HTML fold
+syntax region template keepend start=/<template\( lang="[a-zA-Z]\+"\)\?>/ end="/\s*([^<]?)\s*?\/template([>$]?)\s*/ism" contains=@HTML fold
 
 syntax include @JS syntax/javascript.vim
 unlet b:current_syntax
-syntax region script keepend start=/<script\( lang="[a-zA-Z]\+"\)\?>/ end="</script>" contains=@JS fold
+syntax region script keepend start=/<script\( lang="[a-zA-Z]\+"\)\?>/ end="/\s*([^<]?)\s*?\/script([>$]?)\s*/ism" contains=@JS fold
 
 syntax include @CSS syntax/css.vim
 unlet b:current_syntax
-syntax region style keepend start=/<style\( lang="[a-zA-Z]\+"\)\?>/ end="</style>" contains=@CSS fold
+syntax region style keepend start=/<style\( lang="[a-zA-Z]\+"\)\?>/ end="/\s*([^<]?)\s*?\/style([>$]?)\s*/ism" contains=@CSS fold
 
 let b:current_syntax = "vue"


### PR DESCRIPTION
Previously if one had a Vue template with multiple `<template>` tags, it would break syntax after closing the first child template tag.

```
<template>
  <div>
    <template v-if="condition">
      content
    </template> <!-- Syntax highlighting would stop here -->
  </div>
</template>
```

This just uses regex to make sure it uses the last `</template>` tag as the end point. This adds the same regex pattern to match for the last `</script>` and `</style>` tags even though those are unlikely to be repeated like the `</template>` tag is.